### PR TITLE
Enable landlock kernel arg

### DIFF
--- a/configs/6.1.102.config
+++ b/configs/6.1.102.config
@@ -2658,11 +2658,11 @@ CONFIG_SECURITY_SELINUX_SID2STR_CACHE_SIZE=256
 # CONFIG_SECURITY_YAMA is not set
 # CONFIG_SECURITY_SAFESETID is not set
 # CONFIG_SECURITY_LOCKDOWN_LSM is not set
-# CONFIG_SECURITY_LANDLOCK is not set
+CONFIG_SECURITY_LANDLOCK=y
 # CONFIG_INTEGRITY is not set
 CONFIG_DEFAULT_SECURITY_SELINUX=y
 # CONFIG_DEFAULT_SECURITY_DAC is not set
-CONFIG_LSM="lockdown,yama,loadpin,safesetid,integrity,selinux,smack,tomoyo,apparmor,bpf"
+CONFIG_LSM="landlock,lockdown,yama,loadpin,safesetid,integrity,selinux,smack,tomoyo,apparmor,bpf"
 
 #
 # Kernel hardening options


### PR DESCRIPTION
Enable landlock kernel arg https://docs.kernel.org/userspace-api/landlock.html#boot-time-configuration

This should allow this: https://github.com/openai/codex/blob/e3565a3f438c30c9d36412d2817346c7accd487c/codex-rs/linux-sandbox/src/linux_run_main.rs#L28