### PR TITLE
Modify release asset preparation in workflow

### DIFF
--- a/.github/workflows/fc-kernels.yml
+++ b/.github/workflows/fc-kernels.yml
@@ -77,6 +77,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Prepare release assets
+        if: github.ref_name == 'main'
+        run: |
+          mkdir -p release-assets
+          for dir in ./builds/*/; do
+            name=$(basename "$dir")
+            cp "$dir/vmlinux.bin" "release-assets/vmlinux-${name}.bin"
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Upload Release Asset
         if: github.ref_name == 'main'
         uses: softprops/action-gh-release@v2
@@ -85,5 +96,5 @@ jobs:
         with:
           name: Kernels ${{ steps.get-version.outputs.version }}
           tag_name: ${{ steps.get-version.outputs.version }}
-          files: "./builds/**"
+          files: "./release-assets/*"
       


### PR DESCRIPTION
Updated the workflow to prepare release assets by copying vmlinux binaries to a new directory before uploading.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Collects vmlinux binaries into `release-assets` and uploads those files instead of the raw `builds` directory.
> 
> - **CI workflow (`.github/workflows/fc-kernels.yml`)**:
>   - Add step to assemble release assets: copy each `vmlinux.bin` from `./builds/*/` into `release-assets/` as `vmlinux-<variant>.bin`.
>   - Update release upload to target `./release-assets/*` instead of `./builds/**`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bdad4fa3153508f8d64ae19b29e19bbd369cda44. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->