### PR TITLE
Simplify vmlinux binary naming in release assets

### DIFF
--- a/.github/workflows/fc-kernels.yml
+++ b/.github/workflows/fc-kernels.yml
@@ -83,7 +83,7 @@ jobs:
           mkdir -p release-assets
           for dir in ./builds/*/; do
             name=$(basename "$dir")
-            cp "$dir/vmlinux.bin" "release-assets/vmlinux-${name}.bin"
+            cp "$dir/vmlinux.bin" "release-assets/${name}.bin"
           done
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
remove double vmlinux

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies kernel release asset filenames by removing the `vmlinux-` prefix.
> 
> - **CI workflow (`.github/workflows/fc-kernels.yml`)**:
>   - Adjust release asset naming to copy `vmlinux.bin` as `release-assets/${name}.bin` (removes the `vmlinux-` prefix in filenames).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29c06143457c366198393d29e70d283d2cd0d6b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->