### PR TITLE
Added push protection for other branches

### DIFF
--- a/.github/workflows/fc-kernels.yml
+++ b/.github/workflows/fc-kernels.yml
@@ -2,6 +2,8 @@ name: FC Kernels
 
 on:
   push:
+    branches:
+      - main
 
 permissions:
   id-token: write


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Narrows the CI trigger scope for the `FC Kernels` GitHub Actions workflow.
> 
> - Adds `on.push.branches: [main]` so the workflow runs only on pushes to `main`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9bf00e464704d098ae6c1c8257eb71bb51dd3f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->