### PR TITLE
ARM64 update - PE format needed

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -49,13 +49,22 @@ function build_version {
 
   echo "Building kernel version: $version"
   make $make_opts olddefconfig
-  make $make_opts vmlinux -j "$(nproc)"
+  
+  if [[ "$TARGET_ARCH" == "arm64" ]]; then
+    make $make_opts Image -j "$(nproc)"
+  else
+    make $make_opts vmlinux -j "$(nproc)"
+  fi
 
   echo "Copying finished build to builds directory"
   # Always output to {arch}/ subdirectory
   mkdir -p "../builds/vmlinux-${version}/${TARGET_ARCH}"
-  cp vmlinux "../builds/vmlinux-${version}/${TARGET_ARCH}/vmlinux.bin"
-
+  if [[ "$TARGET_ARCH" == "arm64" ]]; then
+    cp arch/arm64/boot/Image "../builds/vmlinux-${version}/${TARGET_ARCH}/vmlinux.bin"
+  else
+    cp vmlinux "../builds/vmlinux-${version}/${TARGET_ARCH}/vmlinux.bin"
+  fi
+  
   # x86_64: also copy to legacy path (no arch subdir) for backwards compat
   if [[ "$TARGET_ARCH" == "x86_64" ]]; then
     cp vmlinux "../builds/vmlinux-${version}/vmlinux.bin"


### PR DESCRIPTION
arm64 build now provides PE format image, instead of ELF, as expected by firecracker

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, localized change to the build script that only alters the arm64 build artifact/target; main risk is breaking consumers that expected an ELF `vmlinux` for arm64.
> 
> **Overview**
> Updates `build.sh` so **arm64 builds produce a kernel `Image`** (and copy `arch/arm64/boot/Image` to `builds/.../vmlinux.bin`) instead of building/copying the ELF `vmlinux`.
> 
> `x86_64` builds and the legacy `vmlinux.bin` copy path for `x86_64` are unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eafbbcb58838f3deb71b9225985d47516817195b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->