### PR TITLE
Fix and clean up get_tag tag lookup

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -23,10 +23,10 @@ function get_tag {
     local KERNEL_VERSION="${1}"
 
     # list all tags from newest to oldest
-    (
+    {
         git --no-pager tag -l --sort=-creatordate | grep "microvm-kernel-${KERNEL_VERSION}-.*\.amzn2" \
         || git --no-pager tag -l --sort=-creatordate | grep "kernel-${KERNEL_VERSION}-.*\.amzn2"
-    ) | head -n1
+    } | head -n1
 }
 
 function build_version {

--- a/build.sh
+++ b/build.sh
@@ -20,11 +20,13 @@ function install_dependencies {
 
 # prints the git tag corresponding to the newest and best matching the provided kernel version $1
 function get_tag {
-    local KERNEL_VERSION=$1
+    local KERNEL_VERSION="${1}"
 
     # list all tags from newest to oldest
-    (git --no-pager tag -l --sort=-creatordate | grep microvm-kernel-$KERNEL_VERSION\..*\.amzn2 \
-        || git --no-pager tag -l --sort=-creatordate | grep kernel-$KERNEL_VERSION\..*\.amzn2) | head -n1
+    (
+        git --no-pager tag -l --sort=-creatordate | grep "microvm-kernel-${KERNEL_VERSION}-.*\.amzn2" \
+        || git --no-pager tag -l --sort=-creatordate | grep "kernel-${KERNEL_VERSION}-.*\.amzn2"
+    ) | head -n1
 }
 
 function build_version {


### PR DESCRIPTION
The unquoted `\.` was likely a typo for a literal dot, but it expands to `.` (any char), which silently matches the `-` delimiter after the version. Quote the patterns and use an explicit `-` to match the actual tag format.

Also replace the unnecessary subshell with a brace group.