### PR TITLE
fix: avoid mapfile in upload-release-to-gcs.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Release asset naming for that commit:
    vmlinux-<version>.bin           # legacy (= amd64) for backwards compat
    ```
 
-4. The arch-specific binaries are uploaded to each deploy environment's GCS bucket at `gs://$GCP_BUCKET_NAME/kernels/vmlinux-<version>-<short_hash>/<arch>/vmlinux.bin`. Deploy environments: `staging`, `juliett`, `foxtrot`. To upload an existing release to a bucket manually, run `./scripts/upload-release-to-gcs.sh --hash <commit_hash> --bucket <bucket>/kernels` (add `--dry-run` to preview). Existing objects are never overwritten.
+4. The arch-specific binaries are uploaded to each deploy environment's GCS bucket at `gs://$GCP_BUCKET_NAME/kernels/vmlinux-<version>_<short_hash>/<arch>/vmlinux.bin`. Deploy environments: `staging`, `juliett`, `foxtrot`. To upload an existing release to a bucket manually, run `./scripts/upload-release-to-gcs.sh --hash <commit_hash> --bucket <bucket>/kernels` (add `--dry-run` to preview). Existing objects are never overwritten.
 
 ## New kernel in E2B's infra
 _Note: these steps should give you a new kernel on your self-hosted E2B using https://github.com/e2b-dev/infra_

--- a/scripts/upload-release-to-gcs.sh
+++ b/scripts/upload-release-to-gcs.sh
@@ -73,7 +73,10 @@ echo "Release: $RELEASE_TAG (commit ${SHORT_HASH})"
 echo "Target:  ${BUCKET_URI}"
 $DRY_RUN && echo "Mode:    dry-run"
 
-mapfile -t ASSETS < <(gh release view "$RELEASE_TAG" --repo "$REPO" --json assets \
+ASSETS=()
+while IFS= read -r line; do
+  [[ -n "$line" ]] && ASSETS+=("$line")
+done < <(gh release view "$RELEASE_TAG" --repo "$REPO" --json assets \
   --jq '.assets[] | select(.name | test("^vmlinux-.*\\.bin$")) | .name')
 
 if [[ "${#ASSETS[@]}" -eq 0 ]]; then

--- a/scripts/upload-release-to-gcs.sh
+++ b/scripts/upload-release-to-gcs.sh
@@ -74,7 +74,7 @@ echo "Target:  ${BUCKET_URI}"
 $DRY_RUN && echo "Mode:    dry-run"
 
 ASSETS=()
-while IFS= read -r line; do
+while IFS= read -r line || [[ -n "$line" ]]; do
   [[ -n "$line" ]] && ASSETS+=("$line")
 done < <(gh release view "$RELEASE_TAG" --repo "$REPO" --json assets \
   --jq '.assets[] | select(.name | test("^vmlinux-.*\\.bin$")) | .name')

--- a/scripts/upload-release-to-gcs.sh
+++ b/scripts/upload-release-to-gcs.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Uploads vmlinux-*-{amd64,arm64}.bin assets from a fc-kernels GitHub release
 # to GCS at:
-#   gs://<bucket>/vmlinux-<version>-<short_hash>/<arch>/vmlinux.bin
+#   gs://<bucket>/vmlinux-<version>_<short_hash>/<arch>/vmlinux.bin
 #
 # Existing objects are never overwritten. The legacy non-arch release asset
 # (vmlinux-<version>.bin) is intentionally skipped — under a fresh
@@ -96,7 +96,7 @@ for asset in "${ASSETS[@]}"; do
   fi
   version="${BASH_REMATCH[1]}"
   arch="${BASH_REMATCH[2]}"
-  dst="${BUCKET_URI}/vmlinux-${version}-${SHORT_HASH}/${arch}/vmlinux.bin"
+  dst="${BUCKET_URI}/vmlinux-${version}_${SHORT_HASH}/${arch}/vmlinux.bin"
 
   if gcloud storage ls "$dst" >/dev/null 2>&1; then
     echo "  EXISTS  $dst"


### PR DESCRIPTION
\`mapfile\` is bash 4+; macOS ships bash 3.2 at \`/bin/bash\`, so running the script locally errored with \`mapfile: command not found\`. Swap for a portable \`while IFS= read -r line; do ASSETS+=("$line"); done < <(…)\` loop.

Verified on \`GNU bash 3.2.57\` (macOS):

\`\`\`
$ ./scripts/upload-release-to-gcs.sh --hash c1a568c --dry-run --bucket e2b-staging-fc-kernels
Release: 2026.05.11 (commit c1a568c)
Target:  gs://e2b-staging-fc-kernels
Mode:    dry-run
  WOULD   vmlinux-6.1.102-amd64.bin -> gs://e2b-staging-fc-kernels/vmlinux-6.1.102-c1a568c/amd64/vmlinux.bin
  ... (3 more)
Dry run complete. Already in GCS: 0.
\`\`\`