### PR TITLE
refactor: use _hash instead of -hash in GCS path

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Release asset naming for that commit:
    vmlinux-<version>.bin           # legacy (= amd64) for backwards compat
    ```
 
-4. The arch-specific binaries are uploaded to each deploy environment's GCS bucket at `gs://$GCP_BUCKET_NAME/kernels/vmlinux-<version>-<short_hash>/<arch>/vmlinux.bin`. Deploy environments: `staging`, `juliett`, `foxtrot`. To upload an existing release to a bucket manually, run `./scripts/upload-release-to-gcs.sh --hash <commit_hash> --bucket <bucket>/kernels` (add `--dry-run` to preview). Existing objects are never overwritten.
+4. The arch-specific binaries are uploaded to each deploy environment's GCS bucket at `gs://$GCP_BUCKET_NAME/kernels/vmlinux-<version>_<short_hash>/<arch>/vmlinux.bin`. Deploy environments: `staging`, `juliett`, `foxtrot`. To upload an existing release to a bucket manually, run `./scripts/upload-release-to-gcs.sh --hash <commit_hash> --bucket <bucket>/kernels` (add `--dry-run` to preview). Existing objects are never overwritten.
 
 ## New kernel in E2B's infra
 _Note: these steps should give you a new kernel on your self-hosted E2B using https://github.com/e2b-dev/infra_

--- a/scripts/upload-release-to-gcs.sh
+++ b/scripts/upload-release-to-gcs.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Uploads vmlinux-*-{amd64,arm64}.bin assets from a fc-kernels GitHub release
 # to GCS at:
-#   gs://<bucket>/vmlinux-<version>-<short_hash>/<arch>/vmlinux.bin
+#   gs://<bucket>/vmlinux-<version>_<short_hash>/<arch>/vmlinux.bin
 #
 # Existing objects are never overwritten. The legacy non-arch release asset
 # (vmlinux-<version>.bin) is intentionally skipped — under a fresh
@@ -93,7 +93,7 @@ for asset in "${ASSETS[@]}"; do
   fi
   version="${BASH_REMATCH[1]}"
   arch="${BASH_REMATCH[2]}"
-  dst="${BUCKET_URI}/vmlinux-${version}-${SHORT_HASH}/${arch}/vmlinux.bin"
+  dst="${BUCKET_URI}/vmlinux-${version}_${SHORT_HASH}/${arch}/vmlinux.bin"
 
   if gcloud storage ls "$dst" >/dev/null 2>&1; then
     echo "  EXISTS  $dst"


### PR DESCRIPTION
Aligns the kernel GCS path with [fc-versions](https://github.com/e2b-dev/fc-versions)' \`<tag>_<short_hash>\` convention (e.g. \`v1.14.1_458ca91\`):

\`\`\`
gs://<bucket>/vmlinux-<version>_<short_hash>/<arch>/vmlinux.bin
\`\`\`

3 spots touched: script header comment + the \`dst=\` line in \`scripts/upload-release-to-gcs.sh\` + the README example.

Verified with \`--dry-run\`:

\`\`\`
WOULD vmlinux-6.1.102-amd64.bin -> gs://e2b-staging-fc-kernels/vmlinux-6.1.102_c1a568c/amd64/vmlinux.bin
\`\`\`

Note: anything already uploaded with the old dash path is not auto-renamed; future uploads use the underscore.